### PR TITLE
Added syntax testing with gulp as well as an npm startup script

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,7 @@
 var gulp = require('gulp');
 var livereload = require('gulp-livereload');
+var jshint = require('gulp-jshint');
+var stylish = require('jshint-stylish');
 
 /*
 PASTE <script src="//localhost:35729/livereload.js"></script>
@@ -12,13 +14,16 @@ var paths = {
   images: 'client/public/assets/img/*.*',
   styles: 'client/public/assets/css/*.css',
   angComponents: 'client/public/app/**/*.*',
-  html: 'client/public/index.html'
+  html: 'client/public/index.html',
+  server: 'server/**/*.js'
 };
 
 gulp.task('angular', function() {
   return gulp.src([
     paths.angComponents
   ])
+  .pipe(jshint())
+  .pipe(jshint.reporter(stylish))
   .pipe(livereload());
 });
 
@@ -26,6 +31,8 @@ gulp.task('scripts', function() {
   return gulp.src([
     paths.scripts
   ])
+  .pipe(jshint())
+  .pipe(jshint.reporter(stylish))
   .pipe(livereload());
 });
 
@@ -50,6 +57,14 @@ gulp.task('images', function() {
   .pipe(livereload());
 });
 
+gulp.task('server', function() {
+  return gulp.src([
+    paths.server
+  ])
+  .pipe(jshint())
+  .pipe(jshint.reporter(stylish));
+});
+
 gulp.task('watch', function () {
   livereload.listen();
   
@@ -58,8 +73,7 @@ gulp.task('watch', function () {
   gulp.watch(paths.images,['images']);
   gulp.watch(paths.styles,['styles']);
   gulp.watch(paths.angComponents,['angular']);
-
-
+  gulp.watch(paths.server,['server']);
 });
 
 gulp.task('default', ['watch']);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Pickup app server dependencies",
   "main": "index.js",
   "scripts": {
-    "test": "mocha test/server.spec.js"
+    "test": "mocha test/server.spec.js",
+    "start": "gulp watch & nodemon server/server.js"
   },
   "repository": {
     "type": "git",
@@ -34,6 +35,8 @@
     "chai": "~2.3.0",
     "supertest": "~0.15.0",
     "gulp-livereload": "~3.8.0",
-    "gulp": "~3.8.11"
+    "gulp": "~3.8.11",
+    "gulp-jshint": "~1.10.0",
+    "jshint-stylish": "~1.0.2"
   }
 }


### PR DESCRIPTION
- Added gulp-jshint and jshint-stylish to gulpfile
- Gulpfilecan now watch client and server-side to monitor for syntax errors in addition to livereloading
- Package.json has been updated and now both gulp and the server can be run with an "npm start" command
