### PR TITLE
(fix) Corrected gulpfile and jshint config for angular/browser objects

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -17,5 +17,6 @@
     "unused": true,
     "trailing": true,
     "smarttabs": true,
-    "white": true
+    "white": true,
+    "predef": ["angular","google","document","navigator","window"]
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -20,7 +20,7 @@ var paths = {
 
 gulp.task('angular', function() {
   return gulp.src([
-    paths.angComponents
+    paths.angularScripts
   ])
   .pipe(jshint())
   .pipe(jshint.reporter(stylish))

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -13,8 +13,8 @@ var paths = {
   scripts: 'client/public/assets/js/*.js',
   images: 'client/public/assets/img/*.*',
   styles: 'client/public/assets/css/*.css',
-  angComponents: 'client/public/app/**/*.*',
-  html: 'client/public/index.html',
+  angularScripts: 'client/public/app/**/*.js',
+  html: ['client/public/index.html','client/public/app/**/*.html'],
   server: 'server/**/*.js'
 };
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,9 +44,9 @@ gulp.task('styles', function() {
 });
 
 gulp.task('html', function() {
-  return gulp.src([
+  return gulp.src(
     paths.html
-  ])
+  )
   .pipe(livereload());
 });
 


### PR DESCRIPTION
- Changed gulpfile to properly handle angular html partials (no js linting and proper livereload)
- Added angular, document, navigator and window to jshint so they don't throw linting errors
